### PR TITLE
GroupLesson endpoint modification.

### DIFF
--- a/src/controllers/lessons.ts
+++ b/src/controllers/lessons.ts
@@ -3,6 +3,7 @@ import * as httpCodes from '../constants/httpCodes';
 import { LessonService } from '../services/lessons';
 import { Validator, shouldHaveField, ValidationFailed, minLengthShouldBe } from '../validations';
 import { NotFoundError } from '../errors';
+import { State } from '../state';
 
 interface LessonData {
   name: string;
@@ -91,10 +92,13 @@ export async function createGroupLesson(ctx: Koa.ParameterizedContext, next: Koa
   await next();
 }
 
-export async function getGroupLessons(ctx: Koa.ParameterizedContext, next: Koa.Next) {
+export async function getGroupLessons(
+  ctx: Koa.ParameterizedContext<State, Koa.DefaultContext>,
+  next: Koa.Next
+) {
   const lessonService = new LessonService();
   try {
-    const groupLessons = await lessonService.getGroupLessons(ctx.params.group_id);
+    const groupLessons = await lessonService.getGroupLessons(ctx.state.user);
     ctx.body = [...groupLessons];
     ctx.response.status = httpCodes.OK;
   } catch (err) {

--- a/src/repositories/lessons.ts
+++ b/src/repositories/lessons.ts
@@ -21,6 +21,7 @@ export interface DBLesson {
   duration: number;
   description?: string;
   teacher?: Teacher[];
+  subgroup?: number | null;
 }
 
 interface LessonType {
@@ -73,25 +74,27 @@ export async function createGroupLesson(
   });
 }
 
-export async function getGroupLessons(groupId: number) {
+export async function getGroupLessons(groupId: number): Promise<DBLesson[]> {
   return DatabaseConnection.getConnectionPool().connect(async connection => {
-    let groupLessons: DBLesson[];
-    await connection.transaction(async transaction => {
+    return connection.transaction(async transaction => {
       const rows = await transaction.any(sql`
         SELECT lessons.id, lessons.name, lessons.description, lessons.type_id, lessons.location,
-        lessons.start_time, lessons.duration 
+        lessons.start_time, lessons.duration, lesson_groups.subgroup 
         FROM lessons
-        JOIN lesson_groups on lessons.id = lesson_groups.lesson_id
-        WHERE lesson_groups.group_id = ${groupId}
-        `);
+        INNER JOIN lesson_groups on lessons.id = lesson_groups.lesson_id
+        WHERE lesson_groups.group_id = ${groupId}`);
+
+      if (rows.length === 0) {
+        return [];
+      }
 
       const lessonIds = rows.map(row => Number(row.id));
 
       const teachers = await transaction.any(sql`
-          SELECT full_name, lesson_id
-          FROM lesson_teachers
-          JOIN teachers on lesson_teachers.teacher_id = teachers.id
-          WHERE lesson_id IN (${sql.join(lessonIds, sql`,`)})`);
+        SELECT full_name, lesson_id
+        FROM lesson_teachers
+        INNER JOIN teachers on lesson_teachers.teacher_id = teachers.id
+        WHERE lesson_id IN (${sql.join(lessonIds, sql`,`)})`);
 
       const lessonsMap = new Map<number, DBLesson>();
       rows.map(row =>
@@ -104,33 +107,55 @@ export async function getGroupLessons(groupId: number) {
           duration: row.duration as number,
           description: row.description as string,
           teacher: [],
+          subgroup: row.subgroup as number | null,
         })
       );
 
-      groupLessons = teachers.map(teacher => {
+      teachers.map(teacher => {
         const lesson = lessonsMap.get(teacher.lesson_id as number);
         lesson.teacher.push({ fullName: teacher.full_name as string });
         return lesson;
       });
-    });
 
-    return groupLessons;
+      return Array.from(lessonsMap.values());
+    });
   });
 }
 
-export async function getGroupLessonById(
-  groupId: number,
-  lessonId: number
-): Promise<number | null> {
+export async function getGroupLessonById(groupId: number, lessonId: number): Promise<DBLesson> {
   return DatabaseConnection.getConnectionPool().connect(async connection => {
-    const row = await connection.maybeOne(sql`
-    SELECT group_id, lesson_id
-    FROM lesson_groups
-    WHERE group_id = ${groupId} AND lesson_id = ${lessonId}`);
-    if (row) {
-      return row.lesson_id as number;
-    }
-    return null;
+    return connection.transaction(async transaction => {
+      const row = await transaction.maybeOne(sql`
+      SELECT lessons.id, lessons.name, lessons.description, lessons.type_id, 
+      lessons.location, lessons.start_time, lessons.duration, lesson_groups.subgroup
+      FROM lessons
+      INNER JOIN lesson_groups on lessons.id = lesson_groups.lesson_id
+      WHERE lesson_groups.group_id = ${groupId} AND lesson_groups.lesson_id = ${lessonId}`);
+
+      if (!row) {
+        return null;
+      }
+
+      const teachers = await transaction.any(sql`
+          SELECT full_name, lesson_id
+          FROM lesson_teachers
+          JOIN teachers on lesson_teachers.teacher_id = teachers.id
+          WHERE lesson_id = ${row.id}`);
+
+      return {
+        id: row.id as number,
+        name: row.name as string,
+        typeId: row.type_id as number,
+        location: row.location as string,
+        startTime: toDateFromUnix(row.start_time as number),
+        duration: row.duration as number,
+        description: row.description as string,
+        teacher: teachers.map(teacher => ({
+          fullName: teacher.full_name as string,
+        })),
+        subgroup: row.subgroup as number | null,
+      };
+    });
   });
 }
 
@@ -143,6 +168,7 @@ export async function getLessonById(lessonId: number): Promise<DBLesson> {
       FROM lessons
       WHERE id = ${lessonId}
       `);
+
       if (!row) {
         lesson = null;
       }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -71,7 +71,7 @@ router.post(
   shouldHaveAdminRole,
   lessonsControllers.createGroupLesson
 );
-router.get('/groups/:group_id/lessons/', authMiddleware, lessonsControllers.getGroupLessons);
+router.get('/lessons/', authMiddleware, lessonsControllers.getGroupLessons);
 router.post(
   '/groups/:group_id/lessons/:lesson_id/attachments/:attachment_id/',
   authMiddleware,

--- a/src/services/lessons.ts
+++ b/src/services/lessons.ts
@@ -1,7 +1,8 @@
 import * as lessonsRepository from '../repositories/lessons';
-import { getGroupById } from '../repositories/groups';
+import { getGroupById, getMembershipById } from '../repositories/groups';
 import { getTeacherById } from '../repositories/teachers';
 import { NotFoundError } from '../errors';
+import { User } from './users';
 
 interface LessonData {
   name: string;
@@ -21,6 +22,7 @@ export interface Lesson {
   duration: number;
   description?: string;
   teacher?: Teacher[];
+  subgroup?: number | null;
 }
 
 interface LessonType {
@@ -64,13 +66,13 @@ export class LessonService {
     return lessonsRepository.createGroupLesson(lesson, group, subgroup);
   }
 
-  public async getGroupLessons(groupId: number): Promise<Lesson[]> {
-    const group = await getGroupById(groupId);
-    if (!group) {
-      throw new NotFoundError('Group does not exist');
+  public async getGroupLessons(currentUser: User): Promise<Lesson[]> {
+    const currentGroup = await getMembershipById(currentUser.id);
+    if (!currentGroup) {
+      throw new NotFoundError('Group not found');
     }
 
-    const lessons = await lessonsRepository.getGroupLessons(groupId);
+    const lessons = await lessonsRepository.getGroupLessons(currentGroup);
     return lessons.map(lesson => ({
       id: lesson.id,
       name: lesson.name,
@@ -80,6 +82,7 @@ export class LessonService {
       duration: lesson.duration,
       description: lesson.description,
       teacher: lesson.teacher,
+      subgroup: lesson.subgroup,
     }));
   }
 

--- a/src/tests/attachments.test.ts
+++ b/src/tests/attachments.test.ts
@@ -33,7 +33,7 @@ describe('test attachments service', () => {
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getAttachmentById).toBeCalledTimes(1);
     expect(mockedAttachments.assignToGroupLesson).toBeCalledTimes(1);
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect((await mockedAttachments.getAttachmentById(ATTACHMENT_ID)).id).toBe(ATTACHMENT_ID);
   });
 
@@ -72,7 +72,7 @@ describe('test attachments service', () => {
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getAttachmentById).toBeCalledTimes(1);
     expect(mockedAttachments.assignToGroupLesson).not.toBeCalled();
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect(await mockedAttachments.getAttachmentById(ATTACHMENT_ID)).toBeNull();
   });
 
@@ -87,7 +87,7 @@ describe('test attachments service', () => {
 
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getGroupLessonAttachment).toBeCalledTimes(1);
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect(attachments).toEqual([
       { id: 1, name: 'attachment1', url: 'https://attachment.com/4vd1o' },
       { id: 2, name: 'attachment2', url: 'https://attachment.com/4voq' },
@@ -121,7 +121,7 @@ describe('test attachments service', () => {
 
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getGroupLessonAttachment).toBeCalledTimes(1);
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect(attachments).toEqual([]);
   });
 
@@ -139,7 +139,7 @@ describe('test attachments service', () => {
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getAttachmentById).toBeCalledTimes(1);
     expect(mockedAttachments.deleteGroupLessonAttachment).toBeCalledTimes(1);
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect((await mockedAttachments.getAttachmentById(ATTACHMENT_ID)).id).toBe(ATTACHMENT_ID);
   });
 
@@ -179,7 +179,7 @@ describe('test attachments service', () => {
     expect(mockedLessons.getGroupLessonById).toBeCalledTimes(1);
     expect(mockedAttachments.getAttachmentById).toBeCalledTimes(1);
     expect(mockedAttachments.deleteGroupLessonAttachment).not.toBeCalled();
-    expect(await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).toBe(LESSON_ID);
+    expect((await mockedLessons.getGroupLessonById(GROUP_ID, LESSON_ID)).id).toBe(LESSON_ID);
     expect(await mockedAttachments.getAttachmentById(ATTACHMENT_ID)).toBeNull();
   });
 

--- a/src/tests/lessons.test.ts
+++ b/src/tests/lessons.test.ts
@@ -3,7 +3,12 @@ import * as lessonsRepository from '../repositories/lessons';
 import * as groupsRepository from '../repositories/groups';
 import * as teachersRepository from '../repositories/teachers';
 import * as lessonMocks from './mocks/lessons';
-import { getGroupById, getNonexistentGroup } from './mocks/groups';
+import {
+  getGroupById,
+  getNonexistentGroup,
+  getMembershipById,
+  getNonexistentMembershipById,
+} from './mocks/groups';
 import { getTeacherById, getNonexistentTeacher } from './mocks/teachers';
 
 const mockedLessons = lessonsRepository as jest.Mocked<typeof lessonsRepository>;
@@ -107,14 +112,19 @@ describe('test lessons service', () => {
   });
 
   it('test getting lessons of group', async () => {
-    const GROUP_ID = 2;
+    const USER = {
+      id: 1,
+      username: 'user',
+      fullName: 'useruser',
+      role: 1,
+    };
     const lessonService = new LessonService();
-    mockedGroups.getGroupById = getGroupById();
+    mockedGroups.getMembershipById = getMembershipById();
     mockedLessons.getGroupLessons = lessonMocks.getGroupLessons();
 
-    const lessons = await lessonService.getGroupLessons(GROUP_ID);
+    const lessons = await lessonService.getGroupLessons(USER);
 
-    expect(mockedGroups.getGroupById).toBeCalledTimes(1);
+    expect(mockedGroups.getMembershipById).toBeCalledTimes(1);
     expect(mockedLessons.getGroupLessons).toBeCalledTimes(1);
     lessons.map(lesson =>
       expect(Object.keys(lesson)).toEqual([
@@ -126,34 +136,46 @@ describe('test lessons service', () => {
         'duration',
         'description',
         'teacher',
+        'subgroup',
       ])
     );
+    expect(await mockedGroups.getMembershipById(USER.id)).toBe(2);
   });
 
   it('test getting lessons of nonexistent group', async () => {
-    const GROUP_ID = 3;
+    const USER = {
+      id: 1,
+      username: 'user',
+      fullName: 'useruser',
+      role: 1,
+    };
     const lessonService = new LessonService();
-    mockedGroups.getGroupById = getNonexistentGroup();
+    mockedGroups.getMembershipById = getNonexistentMembershipById();
     mockedLessons.getGroupLessons = lessonMocks.getGroupLessons();
 
-    await expect(lessonService.getGroupLessons(GROUP_ID)).rejects.toThrow('Group does not exist');
+    await expect(lessonService.getGroupLessons(USER)).rejects.toThrow('Group not found');
 
-    expect(mockedGroups.getGroupById).toBeCalledTimes(1);
+    expect(mockedGroups.getMembershipById).toBeCalledTimes(1);
     expect(mockedLessons.getGroupLessons).not.toBeCalled();
-    expect(await mockedGroups.getGroupById(GROUP_ID)).toBeNull();
+    expect(await mockedGroups.getMembershipById(USER.id)).toBeNull();
   });
 
   it('test getting emty array lessons of group', async () => {
-    const GROUP_ID = 4;
+    const USER = {
+      id: 1,
+      username: 'user',
+      fullName: 'useruser',
+      role: 1,
+    };
     const lessonService = new LessonService();
-    mockedGroups.getGroupById = getGroupById();
+    mockedGroups.getMembershipById = getMembershipById();
     mockedLessons.getGroupLessons = lessonMocks.getEmptyLessonsArray();
 
-    const lessons = await lessonService.getGroupLessons(GROUP_ID);
+    const lessons = await lessonService.getGroupLessons(USER);
 
-    expect(mockedGroups.getGroupById).toBeCalledTimes(1);
+    expect(mockedGroups.getMembershipById).toBeCalledTimes(1);
     expect(mockedLessons.getGroupLessons).toBeCalledTimes(1);
-    expect((await mockedGroups.getGroupById(GROUP_ID)).id).toBe(GROUP_ID);
+    expect(await mockedGroups.getMembershipById(USER.id)).toBe(2);
     expect(lessons).toEqual([]);
   });
 

--- a/src/tests/mocks/lessons.ts
+++ b/src/tests/mocks/lessons.ts
@@ -2,7 +2,18 @@ import { DBGroup } from '../../repositories/groups';
 import { DBLesson, RawLesson } from '../../repositories/lessons';
 
 export const getGroupLessonById = () =>
-  jest.fn((groupId: number, lessonId: number) => Promise.resolve(lessonId));
+  jest.fn((groupId: number, lessonId: number) =>
+    Promise.resolve({
+      id: lessonId,
+      name: 'lesson1',
+      typeId: 2,
+      location: '610-5',
+      startTime: new Date('2020-01-01T00:00:00'),
+      duration: 100,
+      description: '',
+      teachers: ['Ivanov I.I.'],
+    })
+  );
 
 export const getNonexistentGroupLessonById = () =>
   jest.fn((groupId: number, lessonId: number) => Promise.resolve(null));
@@ -61,6 +72,7 @@ export const getGroupLessons = () =>
         duration: 100,
         description: '',
         teachers: ['Ivanov I.I.'],
+        subgroup: 1,
       },
       {
         id: 2,
@@ -71,6 +83,7 @@ export const getGroupLessons = () =>
         duration: 200,
         description: '',
         teachers: ['Petrov P.P'],
+        subgroup: 1,
       },
     ])
   );


### PR DESCRIPTION
- Modify getGroupLessons endpoint;

- Fix getGroupLessonById and getGroupLessons;

- Add subgroup to lesson displaying;

- Edit attachments and lessons unit tests.